### PR TITLE
A11y Fix: Hide redundant icons for screenreaders

### DIFF
--- a/src/components/sections/ContactInfo.astro
+++ b/src/components/sections/ContactInfo.astro
@@ -45,9 +45,9 @@ const paddingClass = getPaddingClass({ padding, paddingTop, paddingBottom });
                     You can contact us via email or phone.
                 </p>
                 <div class:list={["flex flex-col gap-2 mt-4", textColor]}>
-                    <div class:list={["flex items-center gap-2"]}><Mail /> <a href={`mailto:${siteConfig.Socials.Email}`}>{siteConfig.Socials.Email}</a></div>
-                    <div class:list={["flex items-center gap-2"]}><Phone /> <a href={`tel:${siteConfig.Socials.Phone}`}>{siteConfig.Socials.Phone}</a></div>
-                    <div class:list={["flex items-center gap-2"]}><MapPin /> <a href={`https://maps.google.com/?q=${siteConfig.Socials.Location}`}>{siteConfig.Socials.Location}</a></div>
+                    <div class:list={["flex items-center gap-2"]}><Mail aria-hidden="true" /> <a href={`mailto:${siteConfig.Socials.Email}`}>{siteConfig.Socials.Email}</a></div>
+                    <div class:list={["flex items-center gap-2"]}><Phone aria-hidden="true" /> <a href={`tel:${siteConfig.Socials.Phone}`}>{siteConfig.Socials.Phone}</a></div>
+                    <div class:list={["flex items-center gap-2"]}><MapPin aria-hidden="true" /> <a href={`https://maps.google.com/?q=${siteConfig.Socials.Location}`}>{siteConfig.Socials.Location}</a></div>
                 </div>
             </div>
             <div>

--- a/src/components/sections/Faqs.astro
+++ b/src/components/sections/Faqs.astro
@@ -66,7 +66,8 @@ const textColor = getTextColor(background);
                                 {faq.question}
                             </h3>
                             <Plus 
-                                class="w-6 h-6 flex-shrink-0 transition-transform duration-200 ease-out group-hover:scale-110" 
+                                class="w-6 h-6 flex-shrink-0 transition-transform duration-200 ease-out group-hover:scale-110"
+                                aria-hidden="true"
                             />
                         </button>
                         <div 


### PR DESCRIPTION
This makes some icons invisible for screenreaders that have no label and, thus, are pronounced as “image”:

- The Plus icon in FAQ headers is purely decorative.
- The meaning of the contact icons in ContactInfo is so obvious that hiding them is better than having to read them as “image.” Adding labels would be cleaner, but less pragmatic.