### PR TITLE
Move accordion logic from Faqs to dedicated Details component

### DIFF
--- a/src/components/sections/Faqs.astro
+++ b/src/components/sections/Faqs.astro
@@ -2,8 +2,8 @@
 import type { FaqItem } from '@data/faqs';
 import { getPaddingClass, getBackgroundColor, getHeadlineColor, getTextColor } from '@utils/styleUtils';
 import type { PaddingSize, ThemeColor } from '@utils/styleUtils';
-import { Plus, Minus } from 'lucide-astro';
 import Eyebrow from '@components/ui/Eyebrow.astro';
+import Details from '@components/ui/Details.astro'
 
 export interface Props {
     content: {
@@ -51,90 +51,19 @@ const textColor = getTextColor(background);
         
         <div class="max-w-3xl mx-auto">
             <div class="divide-y divide-gray-200">
-                {faqs.map((faq, index) => (
-                    <div 
-                        class="faq-item py-6"
-                        data-aos="fade-up"
-                        data-aos-delay={index * 100}
-                    >
-                        <button 
-                            class="group w-full flex items-center justify-between text-left cursor-pointer"
-                            aria-expanded="false"
-                            aria-controls={`faq-${index}`}
-                        >
-                            <h3 class:list={["text-xl font-semibold pr-8", headlineColor]}>
-                                {faq.question}
-                            </h3>
-                            <div class="icon-wrapper">
-                                <Plus 
-                                    class="w-6 h-6 flex-shrink-0 transition-transform duration-200 ease-out group-hover:scale-110 plus-icon"
-                                    aria-hidden="true"
-                                />
-                                <Minus 
-                                    class="w-6 h-6 flex-shrink-0 transition-transform duration-200 ease-out group-hover:scale-110 minus-icon hidden"
-                                    aria-hidden="true"
-                                />
-                            </div>
-                        </button>
-                        <div 
-                            id={`faq-${index}`}
-                            class="answer-wrapper grid grid-rows-[0fr] transition-all duration-200 ease-out"
-                            aria-hidden="true"
-                        >
-                            <div class="overflow-hidden">
-                                <div class:list={["pt-4 pr-8 text-small", textColor]}>
-                                    {faq.answer}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                {faqs.map(({ question, answer }, index) => (
+                  <Details
+                    class="py-6"
+                    data-aos="fade-up"
+                    data-aos-delay={index * 100}
+                  >
+                      <span slot="heading" class="pr-8 text-xl font-semibold" class:list={[headlineColor]}>{question}</span>
+                      <div class="overflow-hidden">
+                          <div class:list={["pt-4 pr-8 text-small", textColor]}>{answer}</div>
+                      </div>
+                  </Details>
                 ))}
             </div>
         </div>
     </div>
 </section>
-
-<script>
-    function setupFaqs() {
-        document.querySelectorAll('.faq-item button').forEach(button => {
-            button.addEventListener('click', () => {
-                const isExpanded = button.getAttribute('aria-expanded') === 'true';
-                const wrapper = button.nextElementSibling as HTMLElement;
-                const plusIcon = button.querySelector('.plus-icon');
-                const minusIcon = button.querySelector('.minus-icon');
-                
-                // Toggle current FAQ
-                button.setAttribute('aria-expanded', (!isExpanded).toString());
-                
-                // Toggle icons
-                plusIcon?.classList.toggle('hidden');
-                minusIcon?.classList.toggle('hidden');
-                
-                // Toggle content
-                if (!isExpanded) {
-                    wrapper.style.gridTemplateRows = '1fr';
-                    wrapper.setAttribute('aria-hidden', 'false');
-                } else {
-                    wrapper.style.gridTemplateRows = '0fr';
-                    wrapper.setAttribute('aria-hidden', 'true');
-                }
-            });
-        });
-    }
-
-    // Setup on initial load
-    setupFaqs();
-
-    // Setup on view transitions
-    document.addEventListener('astro:page-load', setupFaqs);
-</script>
-
-<style>
-    .faq-item button:hover svg {
-        color: var(--color-primary-600);
-    }
-    
-    .answer-wrapper {
-        will-change: grid-template-rows;
-    }
-</style>

--- a/src/components/ui/Details.astro
+++ b/src/components/ui/Details.astro
@@ -1,0 +1,92 @@
+---
+import type { HTMLAttributes } from 'astro/types'
+import { Plus, Minus } from 'lucide-astro'
+
+type Props = HTMLAttributes<'div'> & {
+  open?: boolean
+}
+const { open } = Astro.props
+---
+<titan-details open={open} {...Astro.props}>
+    <h3 class="w-full text-left">
+        <button class="group w-full flex items-center justify-between cursor-pointer" aria-expanded={!!open}>
+            <slot name="heading"/>
+            <Plus class="w-6 h-6 flex-shrink-0 transition-transform duration-200 ease-out group-hover:scale-110" aria-hidden="true"/>
+            <Minus class="w-6 h-6 flex-shrink-0 transition-transform duration-200 ease-out group-hover:scale-110" aria-hidden="true"/>
+        </button>
+    </h3>
+    <div class="content grid grid-rows-[0fr] transition-all duration-200 ease-out" aria-hidden={!open}>
+        <slot/>
+    </div>
+</titan-details>
+
+<style>
+    titan-details {
+        display: block;
+    }
+
+    titan-details[open] button svg.lucide-plus, titan-details:not([open]) button svg.lucide-minus {
+        display: none;
+    }
+
+    button:hover svg {
+        color: var(--color-primary-600);
+    }
+
+    .content {
+        grid-template-rows: 0fr;
+    }
+
+    titan-details[open] .content {
+        grid-template-rows: 1fr;
+    }
+</style>
+
+<script>
+  // noinspection JSUnusedGlobalSymbols
+  class TitanDetails extends HTMLElement {
+    get open () {
+      return this.hasAttribute('open')
+    }
+
+    set open (val) {
+      if (val) {
+        this.setAttribute('open', '')
+      } else {
+        this.removeAttribute('open')
+      }
+    }
+
+    $button: HTMLButtonElement
+    $content: HTMLElement
+
+    constructor () {
+      super()
+      this.$button = this.querySelector('button') as HTMLButtonElement
+      this.$content = this.querySelector('.content') as HTMLButtonElement
+      this.$button.addEventListener('click', () => {
+        this.open = !this.open
+      })
+    }
+
+    static get observedAttributes () { return ['open'] }
+
+    attributeChangedCallback (name: string) {
+      if (name === 'open') {
+        this.toggleContent()
+      }
+    }
+
+    toggleContent () {
+      if (this.open) {
+        this.$button.setAttribute('aria-expanded', 'true')
+        this.$content.removeAttribute('aria-hidden')
+      } else {
+        this.$button.setAttribute('aria-expanded', 'false')
+        this.$content.setAttribute('aria-hidden', 'true')
+      }
+    }
+  }
+
+  customElements.define('titan-details', TitanDetails)
+</script>


### PR DESCRIPTION
This refactors the accordion logic from the Faqs section into its own reusable Details component located in `@components/ui/Details.astro`. The Details component imitates the expand/collapse behavior of the native details element, but with working animations and the plus/minus icons, due to poor and inconsistent browser support for native details and summary.

Details.astro has a named header slot and an unnamed content slot. Its logic is implemented as a [custom element](https://docs.astro.build/en/guides/client-side-scripts/#web-components-with-custom-elements) named `titan-details` which brings the following changes:

- The custom element has a public attribute named `open`. Its initial value can be set via astro property. You could, e.g., make the first FAQ item initially expanded.
- This attribute is reflected as a boolean property in the element class. Changing that property programmatically also updates the attribute.
- Clicking the header button toggles the `open` property via click event handler, reflecting to the element's attribute.
- Visual changes like swapping icons or hiding/showing content moved from JS to pure CSS, because the `open` attribute can be used in CSS selectors.
- If the attribute changes, the aria attributes for header and content panel get updated via lifecycle callback.
- A11Y again: The h3 element now encloses the button, because browsers mark headings inside buttons as presentational for assistive technologies. So we get more aligned with WCAG requirements. The appearance remains intact.
- No need to create IDs for each content panel, because the Details component is self-maintained. The `aria-controls` attribute is gone, but this does no harm because most screenreaders don't even care about its presence.

I'm going to use this version in my business site, but of course you're free to merge or not to merge. ;-) Anyway, thank you for this theme. As a blind person, it helps me a lot, because coding is easier for me than designing.