### PR TITLE
A11Y improvement: Hide redundant images for screenreaders

### DIFF
--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -9,7 +9,7 @@ const { variant = 'header' } = Astro.props;
 
 // Determine the appropriate CSS class based on the variant
 const getLogoClass = () => {
-    switch(variant) {
+    switch (variant) {
         case 'header':
             return 'text-header-logo hover:text-primary';
         case 'footer':
@@ -21,10 +21,13 @@ const getLogoClass = () => {
     }
 };
 ---
-<a href="/" class:list={[
-    'logo uppercase font-logo transition-colors duration-200 font-light',
-    getLogoClass()
-]}>
-    <Image src={logo} alt="Logo" class="hidden"/>
+
+<a href="/" class:list={['logo uppercase font-logo transition-colors duration-200 font-light', getLogoClass()]}>
+    {
+        // If image is the only element in this link, its alt attribute should be a textual representation.
+        // Please, use something like your company name or “Home”, not “logo.”
+        // If there is link text, leave alt empty.
+    }
+    <Image src={logo} alt="" class="hidden" />
     <span class="font-bold">Titan</span> Core
 </a>

--- a/src/components/blog/BlogPost.astro
+++ b/src/components/blog/BlogPost.astro
@@ -35,7 +35,7 @@ const validCategories = postCategories.filter((categoryName: string) =>
             featuredImage && (
                 <Image
                     src={featuredImage}
-                    alt={title}
+                    alt=""
                     width={600}
                     height={338}
                     class="object-cover w-full h-full group-hover:scale-105 transition-transform duration-300"
@@ -46,7 +46,7 @@ const validCategories = postCategories.filter((categoryName: string) =>
     </div>
 
     <div class="py-4 px-4 flex flex-col flex-grow relative">
-        <!-- Date at the top -->
+        {/* Date at the top */}
         <div class="text-sm text-gray-600 mb-3 group-hover:text-primary/80 transition-colors duration-300">
             <Date date={publishDate} />
         </div>
@@ -61,7 +61,7 @@ const validCategories = postCategories.filter((categoryName: string) =>
             {excerpt}
         </p>
 
-        <!-- Categories as hashtags at the bottom -->
+        {/* Categories as hashtags at the bottom */}
         <div class="absolute bottom-4 left-4 flex flex-wrap">
             {
                 validCategories.map((categoryName) => (

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -26,9 +26,9 @@ const opacity = content.overlayOpacity ?? 1; // Default opacity if not specified
 <section class="header-offset relative">
     {content.backgroundImage && (
         <div class="absolute inset-0 left-0 top-0 w-full h-full overflow-hidden">
-            <Image 
+            <Image
                 src={content.backgroundImage}
-                alt="Background image"
+                alt=""
                 width={1920}
                 height={1080}
                 class="w-full h-full object-cover"
@@ -37,8 +37,8 @@ const opacity = content.overlayOpacity ?? 1; // Default opacity if not specified
                 loading="eager"
                 decoding="async"
             />
-            <div 
-                class="hero-background absolute inset-0 left-0 top-0 w-full h-full overflow-hidden" 
+            <div
+                class="hero-background absolute inset-0 left-0 top-0 w-full h-full overflow-hidden"
                 style={`opacity: ${opacity};`}
             ></div>
         </div>

--- a/src/components/sections/InnerHero.astro
+++ b/src/components/sections/InnerHero.astro
@@ -19,9 +19,9 @@ const opacity = content.overlayOpacity ?? 1;
 <section class="w-full border-b pt-38 pb-18 relative">
     <div class="absolute inset-0 left-0 top-0 w-full h-full overflow-hidden">
             {content.backgroundImage && (
-                <Image 
+                <Image
                     src={content.backgroundImage}
-                    alt="Background image"
+                    alt=""
                     width={1920}
                     height={1080}
                     class="w-full h-full object-cover"
@@ -29,8 +29,8 @@ const opacity = content.overlayOpacity ?? 1;
                     format="webp"
                 />
             )}
-            <div 
-                class="hero-background absolute inset-0 left-0 top-0 w-full h-full overflow-hidden" 
+            <div
+                class="hero-background absolute inset-0 left-0 top-0 w-full h-full overflow-hidden"
                 style={`opacity: ${opacity};`}
             ></div>
         </div>

--- a/src/components/sections/SplitPanel.astro
+++ b/src/components/sections/SplitPanel.astro
@@ -12,7 +12,7 @@ interface Content {
     description?: string;
     image: {
         src: string | any;
-        alt: string;
+        alt?: string;
     };
     buttons?: {
         text: string;
@@ -43,74 +43,95 @@ const {
 } = Astro.props;
 
 const { eyebrow, headline, subheadline, description, image, buttons = [] } = content;
+const { src, alt = '' } = image;
 
 const paddingClass = getPaddingClass({ padding, paddingTop, paddingBottom });
 const bgColor = getBackgroundColor(background);
 const textColor = getTextColor(background);
 ---
-<section class:list={["relative", bgColor, paddingClass]}>
-    <div class="site-container px-4">
-        <div class:list={[
-            "grid gap-16 items-center",
-            "md:grid-cols-2",
-            imagePosition === 'left' ? 'md:grid-cols-[1fr_1fr]' : ''
-        ]}>
-            <!-- Image Side -->
-            {imagePosition === 'left' && (
-                <div class="relative aspect-[4/3] overflow-hidden rounded-[var(--border-radius-base)] border border-black">
-                    <Image
-                        src={image.src}
-                        alt={image.alt}
-                        width={800}
-                        height={600}
-                        class="w-full h-full object-cover"
-                        quality={80}
-                        format="webp"
-                    />
-                </div>
-            )}
 
-            <!-- Content Side -->
-            <div class:list={[textColor]}>
-                {eyebrow && (
-                    <Eyebrow 
-                        text={eyebrow} 
-                        background={background} 
-                    />
-                )}
-                <h2 class={textColor} data-aos="fade-up">{headline}</h2>
-                {subheadline && <h3 class:list={["mt-4 text-h5", textColor]} data-aos="fade-up">{subheadline}</h3>}
-                {description && <p class:list={["mt-6 text-base opacity-90", textColor]} data-aos="fade-up">{description}</p>}
-                
-                {buttons.length > 0 && (
-                    <div class="flex flex-wrap gap-4 mt-8" data-aos="fade-up">
-                        {buttons.map((button) => (
-                            <Button
-                                href={button.link}
-                                target={button.target || '_self'}
-                                variant={button.variant || 'primary'}
-                            >
-                                {button.text}
-                            </Button>
-                        ))}
+<section class:list={['relative', bgColor, paddingClass]}>
+    <div class="site-container px-4">
+        <div
+            class:list={[
+                'grid gap-16 items-center',
+                'md:grid-cols-2',
+                imagePosition === 'left' ? 'md:grid-cols-[1fr_1fr]' : '',
+            ]}
+        >
+            {/* Image Side */}
+            {
+                imagePosition === 'left' && (
+                    <div class="relative aspect-[4/3] overflow-hidden rounded-[var(--border-radius-base)] border border-black">
+                        <Image
+                            {src}
+                            {alt}
+                            width={800}
+                            height={600}
+                            class="w-full h-full object-cover"
+                            quality={80}
+                            format="webp"
+                        />
                     </div>
-                )}
+                )
+            }
+
+            {/* Content Side */}
+            <div class:list={[textColor]}>
+                {eyebrow && <Eyebrow text={eyebrow} background={background} />}
+                <h2 class={textColor} data-aos="fade-up">{headline}</h2>
+                {
+                    subheadline && (
+                        <h3 class:list={['mt-4 text-h5', textColor]} data-aos="fade-up">
+                            {subheadline}
+                        </h3>
+                    )
+                }
+                {
+                    description && (
+                        <p class:list={['mt-6 text-base opacity-90', textColor]} data-aos="fade-up">
+                            {description}
+                        </p>
+                    )
+                }
+
+                {
+                    buttons.length > 0 && (
+                        <div class="flex flex-wrap gap-4 mt-8" data-aos="fade-up">
+                            {buttons.map((button) => (
+                                <Button
+                                    href={button.link}
+                                    target={button.target || '_self'}
+                                    variant={button.variant || 'primary'}
+                                >
+                                    {button.text}
+                                </Button>
+                            ))}
+                        </div>
+                    )
+                }
             </div>
 
-            <!-- Image Side (right position) -->
-            {imagePosition === 'right' && (
-                <div class="relative aspect-[4/3] overflow-hidden rounded-[var(--border-radius-base)] border border-black" data-aos="fade-up" data-aos-delay="100">
-                    <Image
-                        src={image.src}
-                        alt={image.alt}
-                        width={800}
-                        height={600}
-                        class="w-full h-full object-cover"
-                        quality={80}
-                        format="webp"
-                    />
-                </div>
-            )}
+            {/* Image Side (right position) */}
+            {
+                imagePosition === 'right' && (
+                    <div
+                        class="relative aspect-[4/3] overflow-hidden rounded-[var(--border-radius-base)] border border-black"
+                        data-aos="fade-up"
+                        data-aos-delay="100"
+                    >
+                        <Image
+                            {src}
+                            {alt}
+                            width={800}
+                            height={600}
+                            class="w-full h-full object-cover"
+                            quality={80}
+                            format="webp"
+                        />
+                    </div>
+                )
+            }
         </div>
     </div>
 </section>

--- a/src/components/sections/TeamGrid.astro
+++ b/src/components/sections/TeamGrid.astro
@@ -38,7 +38,7 @@ const sortedTeamMembers = teamMembers.sort((a, b) => a.data.order - b.data.order
                                 {member.data.headshot ? (
                                     <Image
                                         src={member.data.headshot}
-                                        alt={member.data.name}
+                                        alt=""
                                         width={896}
                                         height={1280}
                                         quality={80}

--- a/src/components/team/DesktopProfile.astro
+++ b/src/components/team/DesktopProfile.astro
@@ -1,79 +1,86 @@
 ---
-import { Github, Linkedin, Mail } from 'lucide-astro'
+import { Github, Linkedin, Mail } from 'lucide-astro';
 import X from '@components/icons/X.astro';
 import { Image } from 'astro:assets';
 
-
 interface Props {
-  entry: any; // You might want to type this properly with your collection type
+    entry: any; // You might want to type this properly with your collection type
 }
 
 const { entry } = Astro.props;
 ---
 
 <div class="hidden lg:block">
-<Image
-    class="w-full rounded-md object-cover mb-6 border border-black"
-    src={entry.data.headshot}
-    alt={entry.data.name}
-    width={896}
-    height={1280}
-    quality={80}
-    format="webp"
-/>
-<div class="flex flex-col items-center">
-    <h2 class="text-h5 font-bold text-body-base mb-2">{entry.data.name}</h2>
-    <p class="text-small text-body-base mb-4">{entry.data.jobTitle}</p>
-    
-    <div class="flex flex-col items-center gap-4">
-    {entry.data.email && (
-        <a 
-        href={`mailto:${entry.data.email}`} 
-        class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
-        >
-        <Mail size={18} strokeWidth={1.25} />
-        <span class="break-all">{entry.data.email}</span>
-        </a>
-    )}
-    
-    <div class="flex flex-col items-center gap-3">
-        {entry.data.github && (
-        <a 
-            href={entry.data.github} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
-            aria-label="GitHub Profile"
-        >
-            <Github size={18} strokeWidth={1.25} />
-            {entry.data.githubUsername && <span>{entry.data.githubUsername}</span>}
-        </a>
-        )}
-        {entry.data.xSocial && (
-        <a 
-            href={entry.data.xSocial} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
-            aria-label="X (Twitter) Profile"
-        >
-            <X size={16} />
-            {entry.data.xSocialUsername && <span>@{entry.data.xSocialUsername}</span>}
-        </a>
-        )}
-        {entry.data.linkedin && (
-        <a 
-            href={entry.data.linkedin} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
-            aria-label="LinkedIn Profile"
-        >
-            <Linkedin size={18} strokeWidth={1.25} />
-            {entry.data.linkedinUsername && <span>{entry.data.linkedinUsername}</span>}
-        </a>
-        )}
+    <Image
+        class="w-full rounded-md object-cover mb-6 border border-black"
+        src={entry.data.headshot}
+        alt=""
+        width={896}
+        height={1280}
+        quality={80}
+        format="webp"
+    />
+    <div class="flex flex-col items-center">
+        <h2 class="text-h5 font-bold text-body-base mb-2">{entry.data.name}</h2>
+        <p class="text-small text-body-base mb-4">{entry.data.jobTitle}</p>
+
+        <div class="flex flex-col items-center gap-4">
+            {
+                entry.data.email && (
+                    <a
+                        href={`mailto:${entry.data.email}`}
+                        class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
+                    >
+                        <Mail size={18} strokeWidth={1.25} />
+                        <span class="break-all">{entry.data.email}</span>
+                    </a>
+                )
+            }
+
+            <div class="flex flex-col items-center gap-3">
+                {
+                    entry.data.github && (
+                        <a
+                            href={entry.data.github}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
+                            aria-label="GitHub Profile"
+                        >
+                            <Github size={18} strokeWidth={1.25} />
+                            {entry.data.githubUsername && <span>{entry.data.githubUsername}</span>}
+                        </a>
+                    )
+                }
+                {
+                    entry.data.xSocial && (
+                        <a
+                            href={entry.data.xSocial}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
+                            aria-label="X (Twitter) Profile"
+                        >
+                            <X size={16} />
+                            {entry.data.xSocialUsername && <span>@{entry.data.xSocialUsername}</span>}
+                        </a>
+                    )
+                }
+                {
+                    entry.data.linkedin && (
+                        <a
+                            href={entry.data.linkedin}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
+                            aria-label="LinkedIn Profile"
+                        >
+                            <Linkedin size={18} strokeWidth={1.25} />
+                            {entry.data.linkedinUsername && <span>{entry.data.linkedinUsername}</span>}
+                        </a>
+                    )
+                }
+            </div>
+        </div>
     </div>
-    </div>
-</div>
 </div>

--- a/src/components/team/MobileProfile.astro
+++ b/src/components/team/MobileProfile.astro
@@ -1,81 +1,90 @@
 ---
-import { Github, Linkedin, Mail } from 'lucide-astro'
+import { Github, Linkedin, Mail } from 'lucide-astro';
 import X from '@components/icons/X.astro';
 import { Image } from 'astro:assets';
 interface Props {
-entry: any; // You might want to type this properly with your collection type
+    entry: any; // You might want to type this properly with your collection type
 }
 
 const { entry } = Astro.props;
 ---
+
 <div class="lg:hidden bg-white border border-black p-4 sm:p-6 rounded-md">
-<div class="flex gap-6 sm:gap-8 items-center h-48 sm:h-56">
-    <div class="flex flex-col justify-between min-w-0 flex-1 h-full">
-    <div>
-        <h2 class="text-h5 font-bold text-body-base mb-1">{entry.data.name}</h2>
-        <p class="text-small text-body-base mb-3">{entry.data.jobTitle}</p>
-        
-        {entry.data.email && (
-        <a 
-            href={`mailto:${entry.data.email}`}  
-            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small truncate"
-        >
-            <Mail size={18} strokeWidth={1.25} />
-            <span class="truncate">{entry.data.email}</span>
-        </a>
-        )}
-    </div>
+    <div class="flex gap-6 sm:gap-8 items-center h-48 sm:h-56">
+        <div class="flex flex-col justify-between min-w-0 flex-1 h-full">
+            <div>
+                <h2 class="text-h5 font-bold text-body-base mb-1">{entry.data.name}</h2>
+                <p class="text-small text-body-base mb-3">{entry.data.jobTitle}</p>
 
-    <div class="flex flex-col gap-2 mt-3">
-        {entry.data.github && (
-        <a 
-            href={entry.data.github} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
-            aria-label="GitHub Profile"
-        >
-            <Github size={18} strokeWidth={1.25} />
-            {entry.data.githubUsername && <span>{entry.data.githubUsername}</span>}
-        </a>
-        )}
-        {entry.data.xSocial && (
-        <a 
-            href={entry.data.xSocial} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
-            aria-label="X (Twitter) Profile"
-        >
-            <X size={16} />
-            {entry.data.xSocialUsername && <span>@{entry.data.xSocialUsername}</span>}
-        </a>
-        )}
-        {entry.data.linkedin && (
-        <a 
-            href={entry.data.linkedin} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
-            aria-label="LinkedIn Profile"
-        >
-            <Linkedin size={18} strokeWidth={1.25} />
-            {entry.data.linkedinUsername && <span>{entry.data.linkedinUsername}</span>}
-        </a>
-        )}
-    </div>
-    </div>
+                {
+                    entry.data.email && (
+                        <a
+                            href={`mailto:${entry.data.email}`}
+                            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small truncate"
+                        >
+                            <Mail size={18} strokeWidth={1.25} />
+                            <span class="truncate">{entry.data.email}</span>
+                        </a>
+                    )
+                }
+            </div>
 
-    <div class="h-full aspect-[3/4] shrink-0">
-    <Image
-        class="h-full w-full rounded-md object-cover border border-black"
-        src={entry.data.headshot}
-        alt={entry.data.name}
-        width={896}
-        height={1280}
-        quality={80}
-        format="webp"
-    />
+            <div class="flex flex-col gap-2 mt-3">
+                {
+                    entry.data.github && (
+                        <a
+                            href={entry.data.github}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
+                            aria-label="GitHub Profile"
+                        >
+                            <Github size={18} strokeWidth={1.25} />
+                            {entry.data.githubUsername && <span>{entry.data.githubUsername}</span>}
+                        </a>
+                    )
+                }
+                {
+                    entry.data.xSocial && (
+                        <a
+                            href={entry.data.xSocial}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
+                            aria-label="X (Twitter) Profile"
+                        >
+                            <X size={16} />
+                            {entry.data.xSocialUsername && <span>@{entry.data.xSocialUsername}</span>}
+                        </a>
+                    )
+                }
+                {
+                    entry.data.linkedin && (
+                        <a
+                            href={entry.data.linkedin}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="flex items-center gap-2 text-body-base hover:text-primary transition-colors text-small"
+                            aria-label="LinkedIn Profile"
+                        >
+                            <Linkedin size={18} strokeWidth={1.25} />
+                            {entry.data.linkedinUsername && <span>{entry.data.linkedinUsername}</span>}
+                        </a>
+                    )
+                }
+            </div>
+        </div>
+
+        <div class="h-full aspect-[3/4] shrink-0">
+            <Image
+                class="h-full w-full rounded-md object-cover border border-black"
+                src={entry.data.headshot}
+                alt=""
+                width={896}
+                height={1280}
+                quality={80}
+                format="webp"
+            />
+        </div>
     </div>
-</div>
 </div>

--- a/src/data/logos.ts
+++ b/src/data/logos.ts
@@ -10,7 +10,7 @@ import logo5 from '../assets/images/logos/logoipsum-352.svg';
 
 export interface Logo {
     src: ImageMetadata;
-    alt: string;
+    alt: string; // The partner company's name
 }
 
 export interface LogoList {
@@ -25,24 +25,24 @@ export const logoLists: Record<string, LogoList> = {
         logos: [
             {
                 src: logo1,
-                alt: 'Logo 1',
+                alt: 'Partner 1',
             },
             {
                 src: logo2,
-                alt: 'Logo 2',
+                alt: 'Partner 2',
             },
             {
                 src: logo3,
-                alt: 'Logo 3',
+                alt: 'Partner 3',
             },
             {
                 src: logo4,
-                alt: 'Logo 4',
+                alt: 'Partner 4',
             },
             {
                 src: logo5,
-                alt: 'Logo 5',
-            }
-        ]
-    }
+                alt: 'Partner 5',
+            },
+        ],
+    },
 };

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -44,7 +44,7 @@ else if (!seoImage && post.data.featuredImage) {
                 <>
                     <Image
                         src={post.data.featuredImage}
-                        alt={post.data.title}
+                        alt=""
                         width={1920}
                         height={1080}
                         class="w-full h-full object-cover grayscale opacity-20"
@@ -77,7 +77,7 @@ else if (!seoImage && post.data.featuredImage) {
             post.data.featuredImage && (
                 <Image
                     src={post.data.featuredImage}
-                    alt={post.data.title}
+                    alt=""
                     width={1200}
                     height={675}
                     class="w-full h-auto rounded-lg border mb-12 border-black"


### PR DESCRIPTION
This sets better alt attributes for images. Most of them are decorative or redundant, their alt attributes should be left empty. An empty alt tag lets screenreaders and non-graphical browsers completely ignore the image. Time is valuable for screenreader users, so important information must be prioritized and quickly findable.

- Hero background image: purely decorative, pointless
- Featured blog post images: title is already shown.
- Team member profile and team grid: member name is already shown.
- Logo: Only pure image links **must** have an alt tag as textual representation, otherwise empty.
- Partner logos: Use more sensible alt values in example data.
- SplitPanel: Make alt optional.
