### PR TITLE
More A11Y for desktop navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6106,9 +6106,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-            "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+            "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -35,13 +35,12 @@ const isCurrentPage = (link: string) => {
                                     <a
                                         href={item.link}
                                         class:list={[
-                                            'text-small font-medium rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-nav-text-active',
+                                            'text-small font-medium rounded-md pl-2 py-1 focus:outline-none focus:ring-2 focus:ring-nav-text-active',
+                                            item.children ? 'pr-0' : 'pr-2',
                                             isCurrentPage(item.link)
                                                 ? 'text-nav-text-current font-semibold'
                                                 : 'text-nav-text hover:text-nav-text-hover',
                                         ]}
-                                        aria-expanded={item.children ? 'false' : undefined}
-                                        aria-haspopup={item.children ? 'true' : undefined}
                                         aria-current={isCurrentPage(item.link) ? 'page' : undefined}
                                     >
                                         {item.name}
@@ -53,6 +52,14 @@ const isCurrentPage = (link: string) => {
                                             />
                                         )}
                                     </a>
+                                    {item.children && (
+                                        <button
+                                            type="button"
+                                            class="sr-only"
+                                            aria-expanded="false"
+                                            aria-label={item.name}
+                                        />
+                                    )}
                                 </div>
                                 {item.children && (
                                     <ul
@@ -60,10 +67,9 @@ const isCurrentPage = (link: string) => {
                                             'submenu absolute mt-2 bg-nav-submenu-bg border-black border rounded-md min-w-[200px] transition-all duration-200 opacity-0 invisible overflow-hidden z-50',
                                             index === headerMenu.length - 1 ? 'right-0' : 'left-0',
                                         ]}
-                                        role="menu"
                                     >
                                         {item.children.map((child) => (
-                                            <li role="none">
+                                            <li>
                                                 <a
                                                     href={child.link}
                                                     class:list={[
@@ -72,7 +78,6 @@ const isCurrentPage = (link: string) => {
                                                             ? 'text-nav-text-current font-semibold'
                                                             : 'text-nav-text hover:text-nav-text-hover',
                                                     ]}
-                                                    role="menuitem"
                                                     aria-current={isCurrentPage(child.link) ? 'page' : undefined}
                                                 >
                                                     {child.name}
@@ -187,31 +192,53 @@ const isCurrentPage = (link: string) => {
 
     desktopMenuItems.forEach((item) => {
         const link = item.querySelector('a');
+        const button = item.querySelector('button');
         const submenu = item.querySelector('.submenu');
         const submenuLinks = submenu?.querySelectorAll('a');
 
-        if (submenu && link) {
+        if (submenu && link && button) {
             // Handle hover
             item.addEventListener('mouseenter', () => {
-                showSubmenu(submenu as HTMLElement, link as HTMLElement);
+                showSubmenu(submenu as HTMLElement, button as HTMLElement);
             });
 
             item.addEventListener('mouseleave', () => {
-                hideSubmenu(submenu as HTMLElement, link as HTMLElement);
+                hideSubmenu(submenu as HTMLElement, button as HTMLElement);
             });
 
             // Handle keyboard navigation
             link.addEventListener('keydown', (e) => {
                 if (e.key === 'ArrowDown' && item.children) {
                     e.preventDefault();
-                    showSubmenu(submenu as HTMLElement, link as HTMLElement);
+                    showSubmenu(submenu as HTMLElement, button as HTMLElement);
+                    submenuLinks?.[0]?.focus();
+                }
+            });
+
+            button.addEventListener('click', (e) => {
+                if (item.children) {
+                    e.preventDefault();
+                    const isExpanded = button.getAttribute('aria-expanded') === 'true';
+                    if (isExpanded) {
+                        hideSubmenu(submenu as HTMLElement, button as HTMLElement);
+                    } else {
+                        showSubmenu(submenu as HTMLElement, button as HTMLElement);
+                        submenuLinks?.[0]?.focus();
+                    }
+                }
+            });
+
+            button.addEventListener('keydown', (e) => {
+                if (e.key === 'ArrowDown' && item.children) {
+                    e.preventDefault();
+                    showSubmenu(submenu as HTMLElement, button as HTMLElement);
                     submenuLinks?.[0]?.focus();
                 }
             });
 
             // Don't show submenu on focus, only on hover or arrow key
             link.addEventListener('focus', () => {
-                hideSubmenu(submenu as HTMLElement, link as HTMLElement);
+                hideSubmenu(submenu as HTMLElement, button as HTMLElement);
             });
 
             // Keyboard navigation within submenu
@@ -232,17 +259,17 @@ const isCurrentPage = (link: string) => {
                                 submenuLinks[index - 1].focus();
                             } else {
                                 link.focus();
-                                hideSubmenu(submenu as HTMLElement, link as HTMLElement);
+                                hideSubmenu(submenu as HTMLElement, button as HTMLElement);
                             }
                             break;
                         case 'Escape':
                             e.preventDefault();
-                            hideSubmenu(submenu as HTMLElement, link as HTMLElement);
+                            hideSubmenu(submenu as HTMLElement, button as HTMLElement);
                             link.focus();
                             break;
                         case 'Tab':
                             // Allow normal tab behavior but close submenu
-                            hideSubmenu(submenu as HTMLElement, link as HTMLElement);
+                            hideSubmenu(submenu as HTMLElement, button as HTMLElement);
                             break;
                     }
                 });
@@ -251,23 +278,23 @@ const isCurrentPage = (link: string) => {
             // Close submenu when focus leaves
             document.addEventListener('focusin', (e) => {
                 if (item && !item.contains(e.target as Node)) {
-                    hideSubmenu(submenu as HTMLElement, link as HTMLElement);
+                    hideSubmenu(submenu as HTMLElement, button as HTMLElement);
                 }
             });
         }
     });
 
     // Helper functions
-    function showSubmenu(submenu: HTMLElement, link: HTMLElement) {
+    function showSubmenu(submenu: HTMLElement, button: HTMLElement) {
         submenu.classList.remove('invisible', 'opacity-0');
         submenu.classList.add('visible', 'opacity-100');
-        link.setAttribute('aria-expanded', 'true');
+        button.setAttribute('aria-expanded', 'true');
     }
 
-    function hideSubmenu(submenu: HTMLElement, link: HTMLElement) {
+    function hideSubmenu(submenu: HTMLElement, button: HTMLElement) {
         submenu.classList.add('invisible', 'opacity-0');
         submenu.classList.remove('visible', 'opacity-100');
-        link.setAttribute('aria-expanded', 'false');
+        button.setAttribute('aria-expanded', 'false');
     }
 
     // Simple mobile submenu toggle

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,7 +7,7 @@ import Button from '@components/ui/Button.astro';
 const ctaButton = {
     name: 'Contact Us',
     link: '/contact',
-}
+};
 
 // Get the current path to determine active menu item
 const currentPath = Astro.url.pathname;
@@ -19,175 +19,177 @@ const isCurrentPage = (link: string) => {
     }
     return currentPath.startsWith(link);
 };
-
 ---
 
 <header class="fixed top-0 z-50 w-full left-0">
     <div class="site-container mx-auto px-4 mt-4">
         <div class="flex justify-between items-center bg-white py-4 rounded-lg px-4 border-black border">
-        <Logo />
-        <nav class="relative flex items-center gap-2 lg:gap-8" aria-label="Site Navigation">
-            <!-- Desktop Menu -->
-        <ul class="hidden lg:flex lg:gap-8 items-center">
-            {headerMenu.map((item, index) => (
-                <li class="relative group">
-                    <div class="flex items-center gap-1">
-                        <a 
-                            href={item.link} 
-                            class:list={[
-                                "text-small font-medium rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-nav-text-active",
-                                isCurrentPage(item.link) 
-                                    ? "text-nav-text-current font-semibold" 
-                                    : "text-nav-text hover:text-nav-text-hover"
-                            ]}
-                            aria-expanded={item.children ? "false" : undefined}
-                            aria-haspopup={item.children ? "true" : undefined}
-                            aria-current={isCurrentPage(item.link) ? "page" : undefined}
-                        >
-                            {item.name}
-                            {item.children && item.showArrow && (
-                                <ChevronDown 
-                                    size={16} 
-                                    class="transform transition-transform inline-block ml-1" 
-                                    aria-hidden="true"
-                                />
-                            )}
-                        </a>
-                    </div>
-                    {item.children && (
-                        <ul
-                            class:list={[
-                                "submenu absolute mt-2 bg-nav-submenu-bg border-black border rounded-md min-w-[200px] transition-all duration-200 opacity-0 invisible overflow-hidden z-50",
-                                index === headerMenu.length - 1 ? "right-0" : "left-0"
-                            ]}
-                            role="menu"
-                        >
-                            {item.children.map(child => (
-                                <li role="none">
-                                    <a 
-                                        href={child.link}
+            <Logo />
+            <nav class="relative flex items-center gap-2 lg:gap-8" aria-label="Site Navigation">
+                {/* Desktop Menu */}
+                <ul class="hidden lg:flex lg:gap-8 items-center">
+                    {
+                        headerMenu.map((item, index) => (
+                            <li class="relative group">
+                                <div class="flex items-center gap-1">
+                                    <a
+                                        href={item.link}
                                         class:list={[
-                                            "block px-4 text-small py-2 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-nav-text-active",
-                                            isCurrentPage(child.link) 
-                                                ? "text-nav-text-current font-semibold" 
-                                                : "text-nav-text hover:text-nav-text-hover"
+                                            'text-small font-medium rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-nav-text-active',
+                                            isCurrentPage(item.link)
+                                                ? 'text-nav-text-current font-semibold'
+                                                : 'text-nav-text hover:text-nav-text-hover',
                                         ]}
-                                        role="menuitem"
-                                        aria-current={isCurrentPage(child.link) ? "page" : undefined}
+                                        aria-expanded={item.children ? 'false' : undefined}
+                                        aria-haspopup={item.children ? 'true' : undefined}
+                                        aria-current={isCurrentPage(item.link) ? 'page' : undefined}
                                     >
-                                        {child.name}
+                                        {item.name}
+                                        {item.children && item.showArrow && (
+                                            <ChevronDown
+                                                size={16}
+                                                class="transform transition-transform inline-block ml-1"
+                                                aria-hidden="true"
+                                            />
+                                        )}
                                     </a>
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                </li>
-            ))}
-        </ul>
-
-        <Button href={ctaButton.link} variant="primary" >{ctaButton.name}</Button>
-
-        <!-- Mobile Menu Button -->
-        <button 
-            class="mobile-menu-button relative z-30 p-2 border-none cursor-pointer bg-transparent lg:hidden"
-            aria-label="Toggle Menu"
-            aria-expanded="false"
-        >
-            <span class="menu-icon block">
-                <Menu size={24} class="text-body-base"/>
-            </span>
-            <span class="close-icon hidden">
-                <X size={24} class="text-white"/>
-            </span>
-        </button>
-
-        <!-- Mobile Menu Panel -->
-        <div 
-            class="mobile-menu fixed inset-0 z-20 px-8 pt-20 bg-primary lg:hidden hidden opacity-0 scale-95 transform transition-all duration-200 ease-out overflow-y-auto"
-        >
-            <ul class="flex flex-col gap-4">
-                {headerMenu.map(item => (
-                    <li>
-                        <div class="text-white">
-                            <div class="flex items-center justify-between">
-                                <a 
-                                    href={item.link} 
-                                    class:list={[
-                                        "py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-nav-mobile-text-active",
-                                        isCurrentPage(item.link) 
-                                            ? "text-nav-mobile-text-current font-semibold" 
-                                            : "text-nav-mobile-text hover:text-nav-mobile-text-hover"
-                                    ]}
-                                    aria-current={isCurrentPage(item.link) ? "page" : undefined}
-                                >
-                                    {item.name}
-                                </a>
+                                </div>
                                 {item.children && (
-                                    <button 
+                                    <ul
                                         class:list={[
-                                            "mobile-submenu-button p-2 -mr-2 rounded-md focus:outline-none focus:ring-2 focus:ring-nav-mobile-text-active",
-                                            isCurrentPage(item.link) 
-                                                ? "text-nav-mobile-text-current" 
-                                                : "text-nav-mobile-text hover:text-nav-mobile-text-hover"
+                                            'submenu absolute mt-2 bg-nav-submenu-bg border-black border rounded-md min-w-[200px] transition-all duration-200 opacity-0 invisible overflow-hidden z-50',
+                                            index === headerMenu.length - 1 ? 'right-0' : 'left-0',
                                         ]}
-                                        aria-label={`Toggle ${item.name} submenu`}
-                                        aria-expanded="false"
+                                        role="menu"
                                     >
-                                        <ChevronDown 
-                                            size={16} 
-                                            class="transform transition-transform duration-200" 
-                                        />
-                                    </button>
+                                        {item.children.map((child) => (
+                                            <li role="none">
+                                                <a
+                                                    href={child.link}
+                                                    class:list={[
+                                                        'block px-4 text-small py-2 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-nav-text-active',
+                                                        isCurrentPage(child.link)
+                                                            ? 'text-nav-text-current font-semibold'
+                                                            : 'text-nav-text hover:text-nav-text-hover',
+                                                    ]}
+                                                    role="menuitem"
+                                                    aria-current={isCurrentPage(child.link) ? 'page' : undefined}
+                                                >
+                                                    {child.name}
+                                                </a>
+                                            </li>
+                                        ))}
+                                    </ul>
                                 )}
-                            </div>
-                            {item.children && (
-                                <ul
-                                    class="mobile-submenu ml-4 mt-2 space-y-2 hidden"
-                                    role="menu"
-                                >
-                                    {item.children.map(child => (
-                                        <li role="none">
-                                            <a 
-                                                href={child.link}
+                            </li>
+                        ))
+                    }
+                </ul>
+
+                <Button href={ctaButton.link} variant="primary">{ctaButton.name}</Button>
+
+                {/* Mobile Menu Button */}
+                <button
+                    class="mobile-menu-button relative z-30 p-2 border-none cursor-pointer bg-transparent lg:hidden"
+                    aria-label="Toggle Menu"
+                    aria-expanded="false"
+                >
+                    <span class="menu-icon block">
+                        <Menu size={24} class="text-body-base" />
+                    </span>
+                    <span class="close-icon hidden">
+                        <X size={24} class="text-white" />
+                    </span>
+                </button>
+
+                {/* Mobile Menu Panel */}
+                <div
+                    class="mobile-menu fixed inset-0 z-20 px-8 pt-20 bg-primary lg:hidden hidden opacity-0 scale-95 transform transition-all duration-200 ease-out overflow-y-auto"
+                >
+                    <ul class="flex flex-col gap-4">
+                        {
+                            headerMenu.map((item) => (
+                                <li>
+                                    <div class="text-white">
+                                        <div class="flex items-center justify-between">
+                                            <a
+                                                href={item.link}
                                                 class:list={[
-                                                    "block py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-nav-mobile-text-active",
-                                                    isCurrentPage(child.link) 
-                                                        ? "text-nav-mobile-text-current font-semibold" 
-                                                        : "text-nav-mobile-text hover:text-nav-mobile-text-hover"
+                                                    'py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-nav-mobile-text-active',
+                                                    isCurrentPage(item.link)
+                                                        ? 'text-nav-mobile-text-current font-semibold'
+                                                        : 'text-nav-mobile-text hover:text-nav-mobile-text-hover',
                                                 ]}
-                                                role="menuitem"
-                                                aria-current={isCurrentPage(child.link) ? "page" : undefined}
+                                                aria-current={isCurrentPage(item.link) ? 'page' : undefined}
                                             >
-                                                {child.name}
+                                                {item.name}
                                             </a>
-                                        </li>
-                                    ))}
-                                </ul>
-                            )}
-                        </div>
-                    </li>
-                ))}
-            </ul>
-            
-            <!-- Updated mobile CTA button styling -->
-            <div class="mt-8 pb-8">
-                <Button href={ctaButton.link} variant="ghostLight" >{ctaButton.name}
-                </Button>
-            </div>
+                                            {item.children && (
+                                                <button
+                                                    class:list={[
+                                                        'mobile-submenu-button p-2 -mr-2 rounded-md focus:outline-none focus:ring-2 focus:ring-nav-mobile-text-active',
+                                                        isCurrentPage(item.link)
+                                                            ? 'text-nav-mobile-text-current'
+                                                            : 'text-nav-mobile-text hover:text-nav-mobile-text-hover',
+                                                    ]}
+                                                    aria-label={`Toggle ${item.name} submenu`}
+                                                    aria-expanded="false"
+                                                >
+                                                    <ChevronDown
+                                                        size={16}
+                                                        class="transform transition-transform duration-200"
+                                                    />
+                                                </button>
+                                            )}
+                                        </div>
+                                        {item.children && (
+                                            <ul class="mobile-submenu ml-4 mt-2 space-y-2 hidden" role="menu">
+                                                {item.children.map((child) => (
+                                                    <li role="none">
+                                                        <a
+                                                            href={child.link}
+                                                            class:list={[
+                                                                'block py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-nav-mobile-text-active',
+                                                                isCurrentPage(child.link)
+                                                                    ? 'text-nav-mobile-text-current font-semibold'
+                                                                    : 'text-nav-mobile-text hover:text-nav-mobile-text-hover',
+                                                            ]}
+                                                            role="menuitem"
+                                                            aria-current={
+                                                                isCurrentPage(child.link) ? 'page' : undefined
+                                                            }
+                                                        >
+                                                            {child.name}
+                                                        </a>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                    </div>
+                                </li>
+                            ))
+                        }
+                    </ul>
+
+                    {/* Updated mobile CTA button styling */}
+                    <div class="mt-8 pb-8">
+                        <Button href={ctaButton.link} variant="ghostLight">{ctaButton.name} </Button>
+                    </div>
+                </div>
+            </nav>
         </div>
-        </nav>
     </div>
 </header>
 
 <script>
     // Desktop Menu
     const desktopMenuItems = document.querySelectorAll('.group');
-    
-    desktopMenuItems.forEach(item => {
+
+    desktopMenuItems.forEach((item) => {
         const link = item.querySelector('a');
         const submenu = item.querySelector('.submenu');
         const submenuLinks = submenu?.querySelectorAll('a');
-        
+
         if (submenu && link) {
             // Handle hover
             item.addEventListener('mouseenter', () => {
@@ -269,11 +271,11 @@ const isCurrentPage = (link: string) => {
     }
 
     // Simple mobile submenu toggle
-    document.querySelectorAll('.mobile-submenu-button').forEach(button => {
+    document.querySelectorAll('.mobile-submenu-button').forEach((button) => {
         button.addEventListener('click', () => {
             const submenu = button.parentElement?.nextElementSibling as HTMLElement;
             const chevron = button.querySelector('svg');
-            
+
             // Toggle submenu
             if (submenu) {
                 submenu.classList.toggle('hidden');
@@ -281,7 +283,6 @@ const isCurrentPage = (link: string) => {
                 const isExpanded = submenu.classList.contains('hidden') ? 'false' : 'true';
                 button.setAttribute('aria-expanded', isExpanded);
             }
-
         });
     });
 
@@ -293,7 +294,7 @@ const isCurrentPage = (link: string) => {
 
     mobileMenuButton?.addEventListener('click', () => {
         const isHidden = mobileMenu?.classList.contains('hidden');
-        
+
         if (isHidden) {
             document.body.style.overflow = 'hidden';
             mobileMenu?.classList.remove('hidden');

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -35,8 +35,7 @@ const isCurrentPage = (link: string) => {
                                     <a
                                         href={item.link}
                                         class:list={[
-                                            'text-small font-medium rounded-md pl-2 py-1 focus:outline-none focus:ring-2 focus:ring-nav-text-active',
-                                            item.children ? 'pr-0' : 'pr-2',
+                                            'text-small font-medium rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-nav-text-active',
                                             isCurrentPage(item.link)
                                                 ? 'text-nav-text-current font-semibold'
                                                 : 'text-nav-text hover:text-nav-text-hover',


### PR DESCRIPTION
The dropdown menus in the desktop navigation are a bit confusing for screenreader users, because links are used as links and as top-level menu items simultaniously. Clicking opens the link, and mouse-magic oder some maybe guessable hotkeys open the dropdown. The concept of an „expanded link“ is strange, too. So I did this:

- Added a bogus (invisible) button with class `sr-only`. This button gets the `aria-expanded` attribute and clicking toggles the submenu. I was thinking of making this button visible and putting the arrow in it, but this would require a bit of style tweaking.
- Hover stays like before.
- Removed the menu and menuitem roles. These can be very tricky to implement, and for ordinary nav links, the link behavior is more appropriate. This is a navigation, no productivity app with a complex menu. See [this example](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid/) for more in-depth explanation.
